### PR TITLE
Add content_updated_at column to news table and update related logic

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -578,7 +578,7 @@ const gracefulShutdown = (signal) => {
     httpServer.close(() => {
       console.log('HTTP server closed.');
       console.log('Graceful shutdown completed.');
-      process.exit(0);
+  process.exit(0);
     });
   };
   

--- a/backend/src/admin/controllers/newsController.js
+++ b/backend/src/admin/controllers/newsController.js
@@ -129,6 +129,7 @@ function mapNewsToResponse(n) {
     date: n.date || n.created_at || null,
     created_at: n.created_at || null,
     updated_at: n.updated_at || null,
+    content_updated_at: n.content_updated_at || null, // Only updated when content changes
     status: n.status || 'draft',
     organization_id: n.organization_id || null,
     orgID: n.orgAcronym || (n.organization_id ? `Org-${n.organization_id}` : 'Unknown'),
@@ -462,24 +463,24 @@ export const createNews = async (req, res) => {
       if (statusColumnExists) {
         if (normalizedAction === 'publish' && finalPublishedAt === null) {
           // Use NOW() for published_at when publishing immediately to sync with created_at
-          insertQuery = `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, status, updated_at)
-                         VALUES (?, ?, ?, ?, ?, ?, NOW(), DATE(NOW()), ?, NULL)`;
+          insertQuery = `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, status, updated_at, content_updated_at)
+                         VALUES (?, ?, ?, ?, ?, ?, NOW(), DATE(NOW()), ?, NULL, NULL)`;
           insertParams = [organization.id, title, slug, content || '', excerpt || '', featured_image, status];
         } else {
-          insertQuery = `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, status, updated_at)
-                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`;
+          insertQuery = `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, status, updated_at, content_updated_at)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`;
           insertParams = [organization.id, title, slug, content || '', excerpt || '', featured_image, finalPublishedAt, dateValue, status];
         }
       } else {
         // Fallback: insert without status column (status will be determined by published_at)
         if (normalizedAction === 'publish' && finalPublishedAt === null) {
           // Use NOW() for published_at when publishing immediately to sync with created_at
-          insertQuery = `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, updated_at)
-                         VALUES (?, ?, ?, ?, ?, ?, NOW(), DATE(NOW()), NULL)`;
+          insertQuery = `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, updated_at, content_updated_at)
+                         VALUES (?, ?, ?, ?, ?, ?, NOW(), DATE(NOW()), NULL, NULL)`;
           insertParams = [organization.id, title, slug, content || '', excerpt || '', featured_image];
         } else {
-          insertQuery = `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, updated_at)
-                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`;
+          insertQuery = `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, updated_at, content_updated_at)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`;
           insertParams = [organization.id, title, slug, content || '', excerpt || '', featured_image, finalPublishedAt, dateValue];
         }
       }
@@ -528,15 +529,15 @@ export const createNews = async (req, res) => {
           if (normalizedAction === 'publish' && finalPublishedAt === null) {
             // Use NOW() for published_at when publishing immediately to sync with created_at
             [result] = await db.execute(
-              `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, status, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, NOW(), DATE(NOW()), ?, NULL)`,
+              `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, status, updated_at, content_updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, NOW(), DATE(NOW()), ?, NULL, NULL)`,
               [organization.id, title, slug, content || '', excerpt || '', featured_image, status]
             );
           } else {
             const dateValue = finalPublishedAt ? finalPublishedAt.split(' ')[0] : null;
             [result] = await db.execute(
-              `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, status, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+              `INSERT INTO news (organization_id, title, slug, content, excerpt, featured_image, published_at, date, status, updated_at, content_updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`,
               [organization.id, title, slug, content || '', excerpt || '', featured_image, finalPublishedAt, dateValue, status]
             );
           }
@@ -907,6 +908,7 @@ export const getApprovedNews = async (req, res) => {
               date: row?.date || row?.created_at || null,
               created_at: row?.created_at || null,
               updated_at: row?.updated_at || null,
+              content_updated_at: row?.content_updated_at || null,
               status: row?.status || 'published',
               organization_id: row?.organization_id || null,
               orgID: row?.orgAcronym || 'Unknown',
@@ -1739,32 +1741,32 @@ export const updateNews = async (req, res) => {
     }
     
     // Build UPDATE query
-    // Only update updated_at if there are actual content changes
-    // IMPORTANT: If we don't want to update updated_at, explicitly set it to itself to prevent
-    // MySQL's ON UPDATE CURRENT_TIMESTAMP from auto-updating it when status changes
+    // Use content_updated_at to track when actual content changes (title, content, excerpt, featured_image)
+    // This column is NOT affected by MySQL's ON UPDATE CURRENT_TIMESTAMP
+    // updated_at will still be auto-updated by MySQL for any change (for database tracking)
     let query, params;
-    const updateTimestampClause = shouldUpdateTimestamp 
-      ? ', updated_at = CURRENT_TIMESTAMP' 
-      : ', updated_at = updated_at'; // Preserve current value to prevent auto-update
+    const contentUpdatedAtClause = shouldUpdateTimestamp 
+      ? ', content_updated_at = CURRENT_TIMESTAMP' 
+      : ', content_updated_at = content_updated_at'; // Preserve current value
     
     if (statusColumnExists) {
       if (normalizedAction === 'publish' && finalPublishedAt === null && (currentStatus === 'draft' || currentStatus === 'scheduled')) {
         // Use NOW() for published_at when publishing immediately
-        query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = NOW(), date = DATE(NOW()), status = ?${updateTimestampClause} WHERE id = ?`;
+        query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = NOW(), date = DATE(NOW()), status = ?${contentUpdatedAtClause} WHERE id = ?`;
         params = [title, slug, content || '', excerpt || '', newStatus, id];
       } else {
         // For archive and other actions, use the preserved published_at value
         // Handle NULL values properly in SQL
-        query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = ?, date = ?, status = ?${updateTimestampClause} WHERE id = ?`;
+        query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = ?, date = ?, status = ?${contentUpdatedAtClause} WHERE id = ?`;
         params = [title, slug, content || '', excerpt || '', finalPublishedAt, dateValue, newStatus, id];
       }
     } else {
       // Fallback: without status column
       if (normalizedAction === 'publish' && finalPublishedAt === null && (currentStatus === 'draft' || currentStatus === 'scheduled')) {
-        query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = NOW(), date = DATE(NOW())${updateTimestampClause} WHERE id = ?`;
+        query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = NOW(), date = DATE(NOW())${contentUpdatedAtClause} WHERE id = ?`;
         params = [title, slug, content || '', excerpt || '', id];
       } else {
-        query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = ?, date = ?${updateTimestampClause} WHERE id = ?`;
+        query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = ?, date = ?${contentUpdatedAtClause} WHERE id = ?`;
         params = [title, slug, content || '', excerpt || '', finalPublishedAt, dateValue, id];
       }
     }
@@ -1814,10 +1816,10 @@ export const updateNews = async (req, res) => {
           // Retry the update with status column - use same logic as main query
           if (normalizedAction === 'publish' && finalPublishedAt === null && (currentStatus === 'draft' || currentStatus === 'scheduled')) {
             // Use NOW() for published_at when publishing immediately
-            query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = NOW(), date = DATE(NOW()), status = ?${updateTimestampClause} WHERE id = ?`;
+            query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = NOW(), date = DATE(NOW()), status = ?${contentUpdatedAtClause} WHERE id = ?`;
             params = [title, slug, content || '', excerpt || '', newStatus, id];
           } else {
-            query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = ?, date = ?, status = ?${updateTimestampClause} WHERE id = ?`;
+            query = `UPDATE news SET title = ?, slug = ?, content = ?, excerpt = ?, published_at = ?, date = ?, status = ?${contentUpdatedAtClause} WHERE id = ?`;
             params = [title, slug, content || '', excerpt || '', finalPublishedAt, dateValue, newStatus, id];
           }
           

--- a/backend/src/database.js
+++ b/backend/src/database.js
@@ -847,6 +847,44 @@ const runIncrementalMigrations = async (connection) => {
       });
     }
 
+    // Add content_updated_at column to news table if it doesn't exist
+    // This column tracks when actual content (title, content, excerpt, featured_image) was last edited
+    // It does NOT update when status changes or published_at changes
+    try {
+      const [contentUpdatedColumns] = await connection.query(`
+        SELECT COLUMN_NAME 
+        FROM INFORMATION_SCHEMA.COLUMNS 
+        WHERE TABLE_SCHEMA = DATABASE() 
+        AND TABLE_NAME = 'news' 
+        AND COLUMN_NAME = 'content_updated_at'
+      `);
+      
+      if (contentUpdatedColumns.length === 0) {
+        await connection.query(`
+          ALTER TABLE news 
+          ADD COLUMN content_updated_at TIMESTAMP NULL DEFAULT NULL
+        `);
+        
+        // Initialize content_updated_at for existing news: set to updated_at if it exists and is different from created_at
+        // This preserves existing "last updated" information
+        await connection.query(`
+          UPDATE news 
+          SET content_updated_at = CASE 
+            WHEN updated_at IS NOT NULL AND updated_at != created_at THEN updated_at
+            ELSE NULL
+          END
+        `);
+        
+        logInfo('Added content_updated_at column to news table', { context: 'database' });
+      }
+    } catch (contentUpdatedError) {
+      // Column might already exist or other error - log but continue
+      logWarn('Content updated_at column migration for news table skipped or already exists', { 
+        context: 'database', 
+        error: contentUpdatedError.message 
+      });
+    }
+
     // Legacy superadmin initialization code removed - migration to unified users table is complete
     // Superadmin initialization is now handled in the main initializeDatabase function
 
@@ -1029,6 +1067,7 @@ const initializeDatabase = async () => {
           deleted_at TIMESTAMP NULL,
           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
           updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+          content_updated_at TIMESTAMP NULL DEFAULT NULL,
           FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
           INDEX idx_news_slug (slug),
           INDEX idx_news_published_at (published_at),

--- a/frontend/src/app/(public)/news/[slug]/page.js
+++ b/frontend/src/app/(public)/news/[slug]/page.js
@@ -130,26 +130,22 @@ export default function NewsDetailPage({ params }) {
           <div className={styles.newsMetaInfo}>
             <div><em>Published:</em> {formatDate(news.published_at || news.date)}</div>
             {(() => {
-              // Only show "Last Updated" if updated_at exists and is meaningfully different from published_at
-              // This ensures we only show it when there was an actual content edit, not when status changed
-              if (!news.updated_at || !news.published_at) {
+              // Only show "Last Updated" if content_updated_at exists
+              // content_updated_at only tracks actual content edits (title, content, excerpt, featured_image)
+              // It does NOT update when status changes or published_at changes
+              if (!news.content_updated_at) {
                 return null;
               }
               
-              const publishedDate = new Date(news.published_at);
-              const updatedDate = new Date(news.updated_at);
+              const updatedDate = new Date(news.content_updated_at);
               
-              // Check if dates are valid
-              if (isNaN(publishedDate.getTime()) || isNaN(updatedDate.getTime())) {
+              // Check if date is valid
+              if (isNaN(updatedDate.getTime())) {
                 return null;
               }
               
-              // Only show if updated_at is significantly different from published_at (at least 5 seconds)
-              const timeDifference = updatedDate.getTime() - publishedDate.getTime();
-              if (timeDifference > 5000) { // 5 seconds threshold
-                return <div><em>Last Updated:</em> {formatDate(news.updated_at)}</div>;
-              }
-              return null;
+              // Show content_updated_at if it exists (it only exists when content was actually edited)
+              return <div><em>Last Updated:</em> {formatDate(news.content_updated_at)}</div>;
             })()}
             <div><em>By:</em> {news.orgName || news.orgID || 'Unknown Organization'}</div>
           </div>

--- a/frontend/src/app/admin/news/components/PostForm/CreatePostForm.js
+++ b/frontend/src/app/admin/news/components/PostForm/CreatePostForm.js
@@ -36,14 +36,15 @@ const CreatePostForm = ({ onSubmit, isSubmitting = false, initialData = null, is
         // For published/archived news, published_at should always exist
         // Do NOT fall back to date field - published_at is the source of truth
         originalPublishedAt: shouldShowPublishedDate ? (initialData.published_at || null) : null,
-        updatedAt: initialData.updated_at || null,
+        // Use content_updated_at instead of updated_at - only tracks actual content edits
+        updatedAt: initialData.content_updated_at || null,
         status: currentStatus,
         createdAt: initialData.created_at || null,
       };
     }
     return {
       originalPublishedAt: null,
-      updatedAt: null,
+      updatedAt: null, // Will use content_updated_at when available
       status: null,
       createdAt: null,
     };
@@ -150,7 +151,8 @@ const CreatePostForm = ({ onSubmit, isSubmitting = false, initialData = null, is
         // For published/archived news, published_at should always exist
         // Do NOT fall back to date field - published_at is the source of truth
         originalPublishedAt: shouldShowPublishedDate ? (initialData.published_at || null) : null,
-        updatedAt: initialData.updated_at || null,
+        // Use content_updated_at instead of updated_at - only tracks actual content edits
+        updatedAt: initialData.content_updated_at || null,
         status: currentStatus,
         createdAt: initialData.created_at || null,
       });
@@ -1035,43 +1037,33 @@ const CreatePostForm = ({ onSubmit, isSubmitting = false, initialData = null, is
                   </div>
                 )}
 
-                {/* Last Updated - Only show if updatedAt is different from publishedAt (meaning there was an actual content edit after publication) */}
+                {/* Last Updated - Only show if content_updated_at exists (meaning there was an actual content edit) */}
                 {(() => {
-                  // Only show "Last Updated" if:
-                  // 1. updatedAt exists
-                  // 2. publishedAt exists (to compare against)
-                  // 3. updatedAt is meaningfully different from publishedAt (at least 5 seconds difference)
-                  //    This ensures we only show "Last Updated" when there was an actual content edit,
-                  //    not when status changed from scheduled to published (which shouldn't update updated_at anyway)
-                  if (!readOnlyFields.updatedAt || !readOnlyFields.originalPublishedAt) {
+                  // content_updated_at only exists when actual content was edited (title, content, excerpt, featured_image)
+                  // It does NOT update when status changes or published_at changes
+                  // So if it exists, we should show it
+                  if (!readOnlyFields.updatedAt) {
                     return null;
                   }
                   
-                  const publishedDate = new Date(readOnlyFields.originalPublishedAt);
                   const updatedDate = new Date(readOnlyFields.updatedAt);
                   
-                  // Check if dates are valid
-                  if (isNaN(publishedDate.getTime()) || isNaN(updatedDate.getTime())) {
+                  // Check if date is valid
+                  if (isNaN(updatedDate.getTime())) {
                     return null;
                   }
                   
-                  // Only show if updatedAt is significantly different from publishedAt (at least 5 seconds)
-                  // This threshold helps filter out cases where updated_at might have been set incorrectly
-                  // or when there are minor timestamp differences due to database operations
-                  const timeDifference = updatedDate.getTime() - publishedDate.getTime();
-                  if (timeDifference > 5000) { // 5 seconds threshold
-                    return (
-                      <div className={styles.historyItem}>
-                        <div className={styles.historyDot}></div>
-                        <div className={styles.historyContent}>
-                          <div className={styles.historyLabel}>Last Updated</div>
-                          <div className={styles.historyDate}>{formatDateTime(readOnlyFields.updatedAt)}</div>
-                          <div className={styles.historyRelativeTime}>{getRelativeTime(readOnlyFields.updatedAt)}</div>
-                        </div>
+                  // Show content_updated_at if it exists (it only exists when content was actually edited)
+                  return (
+                    <div className={styles.historyItem}>
+                      <div className={styles.historyDot}></div>
+                      <div className={styles.historyContent}>
+                        <div className={styles.historyLabel}>Last Updated</div>
+                        <div className={styles.historyDate}>{formatDateTime(readOnlyFields.updatedAt)}</div>
+                        <div className={styles.historyRelativeTime}>{getRelativeTime(readOnlyFields.updatedAt)}</div>
                       </div>
-                    );
-                  }
-                  return null;
+                    </div>
+                  );
                 })()}
 
                 {/* Show message if no history available */}

--- a/frontend/src/app/admin/news/components/ViewDetailsModal/ViewDetailsModal.js
+++ b/frontend/src/app/admin/news/components/ViewDetailsModal/ViewDetailsModal.js
@@ -153,31 +153,27 @@ const ViewDetailsModal = ({ news, onClose }) => {
               </div>
             )}
             {(() => {
-              // Only show "Last Updated" if updated_at exists and is meaningfully different from published_at
-              // This ensures we only show it when there was an actual content edit, not when status changed
-              if (!news.updated_at || !news.published_at) {
+              // Only show "Last Updated" if content_updated_at exists
+              // content_updated_at only tracks actual content edits (title, content, excerpt, featured_image)
+              // It does NOT update when status changes or published_at changes
+              if (!news.content_updated_at) {
                 return null;
               }
               
-              const publishedDate = new Date(news.published_at);
-              const updatedDate = new Date(news.updated_at);
+              const updatedDate = new Date(news.content_updated_at);
               
-              // Check if dates are valid
-              if (isNaN(publishedDate.getTime()) || isNaN(updatedDate.getTime())) {
+              // Check if date is valid
+              if (isNaN(updatedDate.getTime())) {
                 return null;
               }
               
-              // Only show if updated_at is significantly different from published_at (at least 5 seconds)
-              const timeDifference = updatedDate.getTime() - publishedDate.getTime();
-              if (timeDifference > 5000) { // 5 seconds threshold
-                return (
-                  <div className={styles.infoItem}>
-                    <span className={styles.infoLabel}>Last Updated</span>
-                    <span className={styles.infoValue}>{formatDateTimeDisplay(news.updated_at)}</span>
-                  </div>
-                );
-              }
-              return null;
+              // Show content_updated_at if it exists (it only exists when content was actually edited)
+              return (
+                <div className={styles.infoItem}>
+                  <span className={styles.infoLabel}>Last Updated</span>
+                  <span className={styles.infoValue}>{formatDateTimeDisplay(news.content_updated_at)}</span>
+                </div>
+              );
             })()}
           </div>
         </div>


### PR DESCRIPTION
- Introduced a new column `content_updated_at` in the news table to track actual content changes, ensuring it only updates when title, content, excerpt, or featured_image are modified.
- Updated database migration logic to add the column if it doesn't exist and initialize it for existing records.
- Modified news handling in various components to utilize `content_updated_at` instead of `updated_at`, enhancing clarity on when content was last edited.
- Adjusted frontend components to display the "Last Updated" timestamp based on `content_updated_at`, improving user experience by accurately reflecting content changes.