### PR TITLE
Update Node.js version in nixpacks and specify engine requirement in …

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,9 @@
   "author": "FAITH CommUNITY",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.943.0",
     "@aws-sdk/lib-storage": "^3.943.0",

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -3,7 +3,7 @@
 # Note: If rootDirectory is set in railway.json, Railway will already be in the backend directory
 
 [phases.setup]
-nixPkgs = ["nodejs-18_x"]
+nixPkgs = ["nodejs-20_x"]
 
 [phases.install]
 cmds = ["npm install"]


### PR DESCRIPTION
…package.json

- Changed the Node.js version from 18.x to 20.x in nixpacks.toml to align with the latest standards.
- Added an "engines" field in package.json to specify that the project requires Node.js version 20.0.0 or higher.