### PR TITLE
Update font sizes in StarPreviewOverlay CSS for improved readability

### DIFF
--- a/frontend/src/app/(public)/faithree/components/StarPreviewOverlay/StarPreviewOverlay.module.css
+++ b/frontend/src/app/(public)/faithree/components/StarPreviewOverlay/StarPreviewOverlay.module.css
@@ -127,7 +127,7 @@
 
 /* Title */
 .title {
-  font-size: 17px;
+  font-size: 15px;
   font-weight: 800;
   color: #1b5e20;
   margin: 0;
@@ -195,7 +195,7 @@
   }
 
   .title {
-    font-size: 15px;
+    font-size: 14px;
   }
 
   .orgSection {


### PR DESCRIPTION
- Reduced the font size of the title in both default and responsive styles from 17px to 15px and from 15px to 14px, respectively, enhancing the overall visual hierarchy and consistency.